### PR TITLE
new "detected_buildpack" tag and updating the 'buildpack' tag to match API

### DIFF
--- a/collectors/applications_collector.go
+++ b/collectors/applications_collector.go
@@ -45,7 +45,7 @@ func NewApplicationsCollector(
 			Help:        "Labeled Cloud Foundry Application information with a constant '1' value.",
 			ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
 		},
-		[]string{"application_id", "application_name", "buildpack", "organization_id", "organization_name", "space_id", "space_name", "stack_id", "state"},
+		[]string{"application_id", "application_name", "detected_buildpack", "buildpack", "organization_id", "organization_name", "space_id", "space_name", "stack_id", "state"},
 	)
 
 	applicationInstancesMetric := prometheus.NewGaugeVec(
@@ -272,9 +272,14 @@ func (c ApplicationsCollector) getSpaceSummary(ch chan<- prometheus.Metric, orga
 	}
 
 	for _, application := range spaceSummary.Apps {
-		buildpack := application.DetectedBuildpack
+		detected_buildpack := application.DetectedBuildpack
 		if buildpack == "" {
 			buildpack = application.Buildpack
+		}
+		
+		buildpack := application.Buildpack
+		if buildpack == "" {
+			buildpack = application.DetectedBuildpack
 		}
 
 		c.applicationInfoMetric.WithLabelValues(


### PR DESCRIPTION
This is to add a new 'detected_buildpack' field to the cf_applications_info metric which reflects the 'detected_buildpack' parameter from the API and changes the 'buildpack' tag to reflect the 'buildpack' parameter from the API.  Previously the 'buildpack' tag reflected the 'detected_buildpack' parameter from the API causing a mismatch and the two parameters do hold different information.