### PR TITLE
create new 'detected_buildpack' tag and update 'buildpack' tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The exporter returns the following `Applications` metrics:
 
 | Metric | Description | Labels |
 | ------ | ----------- | ------ |
-| *metrics.namespace*_application_info | Labeled Cloud Foundry Application information with a constant `1` value | `environment`, `deployment`, `application_id`, `application_name`, `buildpack`, `organization_id`, `organization_name`, `space_id`, `space_name`, `stack_id`, `state` |
+| *metrics.namespace*_application_info | Labeled Cloud Foundry Application information with a constant `1` value | `environment`, `deployment`, `application_id`, `application_name`, `detected_buildpack`, `buildpack`, `organization_id`, `organization_name`, `space_id`, `space_name`, `stack_id`, `state` |
 | *metrics.namespace*_application_instances | Number of desired Cloud Foundry Application Instances | `environment`, `deployment`, `application_id`, `application_name`, `organization_id`, `organization_name`, `space_id`, `space_name`, `state` |
 | *metrics.namespace*_application_instances_running | Number of running Cloud Foundry Application Instances | `environment`, `deployment`, `application_id`, `application_name`, `organization_id`, `organization_name`, `space_id`, `space_name`, `state` |
 | *metrics.namespace*_application_memory_mb | Cloud Foundry Application Memory (Mb) | `environment`, `deployment`, `application_id`, `application_name`, `organization_id`, `organization_name`, `space_id`, `space_name` |

--- a/collectors/applications_collector.go
+++ b/collectors/applications_collector.go
@@ -45,7 +45,7 @@ func NewApplicationsCollector(
 			Help:        "Labeled Cloud Foundry Application information with a constant '1' value.",
 			ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
 		},
-		[]string{"application_id", "application_name", "buildpack", "organization_id", "organization_name", "space_id", "space_name", "stack_id", "state"},
+		[]string{"application_id", "application_name", "detected_buildpack", "buildpack", "organization_id", "organization_name", "space_id", "space_name", "stack_id", "state"},
 	)
 
 	applicationInstancesMetric := prometheus.NewGaugeVec(
@@ -272,6 +272,11 @@ func (c ApplicationsCollector) getSpaceSummary(ch chan<- prometheus.Metric, orga
 	}
 
 	for _, application := range spaceSummary.Apps {
+		detected_buildpack := application.DetectedBuildpack
+		if detected_buildpack == "" {
+			detected_buildpack = application.Buildpack
+		}
+		
 		buildpack := application.Buildpack
 		if buildpack == "" {
 			buildpack = application.DetectedBuildpack
@@ -280,6 +285,7 @@ func (c ApplicationsCollector) getSpaceSummary(ch chan<- prometheus.Metric, orga
 		c.applicationInfoMetric.WithLabelValues(
 			application.Guid,
 			application.Name,
+			detected_buildpack,
 			buildpack,
 			organization.Guid,
 			organization.Name,

--- a/collectors/applications_collector.go
+++ b/collectors/applications_collector.go
@@ -272,9 +272,9 @@ func (c ApplicationsCollector) getSpaceSummary(ch chan<- prometheus.Metric, orga
 	}
 
 	for _, application := range spaceSummary.Apps {
-		buildpack := application.DetectedBuildpack
+		buildpack := application.Buildpack
 		if buildpack == "" {
-			buildpack = application.Buildpack
+			buildpack = application.DetectedBuildpack
 		}
 
 		c.applicationInfoMetric.WithLabelValues(

--- a/collectors/applications_collector_test.go
+++ b/collectors/applications_collector_test.go
@@ -42,6 +42,7 @@ var _ = Describe("ApplicationsCollectors", func() {
 
 		applicationId1    = "fake_application_id_1"
 		applicationName1  = "fake_application_name_1"
+		detectedbuildpack1= "fake_detected_buildpack_1"
 		buildpack1        = "fake_buildpack_1"
 		organizationId1   = "fake_organization_id_1"
 		organizationName1 = "fake_organization_name_1"
@@ -56,6 +57,7 @@ var _ = Describe("ApplicationsCollectors", func() {
 
 		applicationId2    = "fake_application_id_2"
 		applicationName2  = "fake_application_name_2"
+		detectedbuildpack2= "fake_detected_buildpack_2"
 		buildpack2        = "fake_buildpack_2"
 		organizationId2   = "fake_organization_id_2"
 		organizationName2 = "fake_organization_name_2"
@@ -95,10 +97,10 @@ var _ = Describe("ApplicationsCollectors", func() {
 				Help:        "Labeled Cloud Foundry Application information with a constant '1' value.",
 				ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
 			},
-			[]string{"application_id", "application_name", "buildpack", "organization_id", "organization_name", "space_id", "space_name", "stack_id", "state"},
+			[]string{"application_id", "application_name", "detected_buildpack", "buildpack", "organization_id", "organization_name", "space_id", "space_name", "stack_id", "state"},
 		)
-		applicationInfoMetric.WithLabelValues(applicationId1, applicationName1, buildpack1, organizationId1, organizationName1, spaceId1, spaceName1, stackId1, state1).Set(1)
-		applicationInfoMetric.WithLabelValues(applicationId2, applicationName2, buildpack2, organizationId2, organizationName2, spaceId2, spaceName2, stackId2, state2).Set(1)
+		applicationInfoMetric.WithLabelValues(applicationId1, applicationName1, detectedbuildpack1, buildpack1, organizationId1, organizationName1, spaceId1, spaceName1, stackId1, state1).Set(1)
+		applicationInfoMetric.WithLabelValues(applicationId2, applicationName2, detectedbuildpack2, buildpack2, organizationId2, organizationName2, spaceId2, spaceName2, stackId2, state2).Set(1)
 
 		applicationInstancesMetric = prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -229,6 +231,7 @@ var _ = Describe("ApplicationsCollectors", func() {
 			Eventually(descriptions).Should(Receive(Equal(applicationInfoMetric.WithLabelValues(
 				applicationId1,
 				applicationName1,
+				detectedbuildpack1,
 				buildpack1,
 				organizationId1,
 				organizationName1,
@@ -382,8 +385,8 @@ var _ = Describe("ApplicationsCollectors", func() {
 						DiskQuota:         diskQuotaMb1,
 						StackGuid:         stackId1,
 						State:             state1,
-						Buildpack:         "",
-						DetectedBuildpack: buildpack1,
+						Buildpack:         buildpack1,
+						DetectedBuildpack: detectedbuildpack1,
 					},
 				},
 			}
@@ -402,7 +405,7 @@ var _ = Describe("ApplicationsCollectors", func() {
 						StackGuid:         stackId2,
 						State:             state2,
 						Buildpack:         buildpack2,
-						DetectedBuildpack: "",
+						DetectedBuildpack: detectedbuildpack2,
 					},
 				},
 			}
@@ -445,6 +448,7 @@ var _ = Describe("ApplicationsCollectors", func() {
 			Eventually(metrics).Should(Receive(PrometheusMetric(applicationInfoMetric.WithLabelValues(
 				applicationId1,
 				applicationName1,
+				detectedbuildpack1,
 				buildpack1,
 				organizationId1,
 				organizationName1,
@@ -459,6 +463,7 @@ var _ = Describe("ApplicationsCollectors", func() {
 			Eventually(metrics).Should(Receive(PrometheusMetric(applicationInfoMetric.WithLabelValues(
 				applicationId2,
 				applicationName2,
+				detectedbuildpack2,
 				buildpack2,
 				organizationId2,
 				organizationName2,


### PR DESCRIPTION
This is to update the existing 'buildpack' tag on the cf_applications_info metric to reflect the 'buildpack' parameter in the API and add a new 'detected_buildpack' tag to reflect the 'detected_buildpack' API parameter.  Previously 'buildpack' used 'detected_buildpack' from the API rather than 'buildpack' and since these contain different information in most cases, it caused unexpected results.  I have tested this change in my own PCF environment.  Example:

cf_application_info{application_id="<redacted>",application_name="logs-queue-blue",buildpack="binary_buildpack",deployment="<redacted>",detected_buildpack="binary",environment="<redacted>",organization_id="<redacted>",organization_name="system",space_id="<redacted>",space_name="metrics-v1-6",stack_id="<redacted>",state="STOPPED"} 1