### PR TITLE
Add Buildpacks collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ uaac client add prometheus-cf \
 | `cf.deployment-name`<br />`CF_EXPORTER_CF_DEPLOYMENT_NAME` | Yes | | Cloud Foundry Deployment Name to be reported as a metric label |
 | `cf.api-v3-enabled`<br />`CF_EXPORTER_CF_API_V3_ENABLED` | No | False | Enable [Cloud Foundry API V3][cf_api_v3] calls |
 | `events.query`<br />`CF_EXPORTER_EVENTS_QUERY` | No | | When the `Events` filter is enabled and this value is set, this query is sent to the CloudController to limit the number of results returned. Syntax is exactly as documented at the [Cloud Foundry API][cf_api] |
-| `filter.collectors`<br />`CF_EXPORTER_FILTER_COLLECTORS` | No | | Comma separated collectors to filter. If not set, all collectors except `Events` will be enabled (`Applications`, `Events`, `IsolationSegments`, `Organizations`, `Routes`, `SecurityGroups`, `ServiceBindings`, `ServiceInstances`, `ServicePlans`, `Services`, `Spaces`, `Stacks`). `IsolationSegments` collector requires `cf.api-v3-enabled` enabled |
+| `filter.collectors`<br />`CF_EXPORTER_FILTER_COLLECTORS` | No | | Comma separated collectors to filter. If not set, all collectors except `Events` will be enabled (`Applications`, `Buildpacks`,`Events`, `IsolationSegments`, `Organizations`, `Routes`, `SecurityGroups`, `ServiceBindings`, `ServiceInstances`, `ServicePlans`, `Services`, `Spaces`, `Stacks`). `IsolationSegments` collector requires `cf.api-v3-enabled` enabled |
 | `metrics.namespace`<br />`CF_EXPORTER_METRICS_NAMESPACE` | No | `cf` | Metrics Namespace |
 | `metrics.environment`<br />`CF_EXPORTER_METRICS_ENVIRONMENT` | Yes | | Environment label to be attached to metrics |
 | `skip-ssl-verify`<br />`CF_EXPORTER_SKIP_SSL_VERIFY` | No | `false` | Disable SSL Verify |
@@ -112,6 +112,16 @@ The exporter returns the following `Applications` metrics:
 | *metrics.namespace*_last_applications_scrape_timestamp | Number of seconds since 1970 since last scrape of Applications metrics from Cloud Foundry | `environment`, `deployment` |
 | *metrics.namespace*_last_applications_scrape_duration_seconds | Duration of the last scrape of Applications metrics from Cloud Foundry | `environment`, `deployment` |
 
+The exporter returns the following `Buildpacks` metrics:
+
+| Metric | Description | Labels |
+| ------ | ----------- | ------ |
+| *metrics.namespace*_buildpack_info | Labeled Cloud Foundry Buildpacks information with a constant `1` value | `environment`, `deployment`, `buildpack_id`, `buildpack_name`, `buildpack_stack`, `buildpack_filename` |
+| *metrics.namespace*_buildpacks_scrapes_total | Total number of scrapes for Cloud Foundry Buildpacks | `environment`, `deployment` |
+| *metrics.namespace*_buildpacks_scrape_errors_total | Total number of scrape errors of Cloud Foundry Buildpacks | `environment`, `deployment` |
+| *metrics.namespace*_last_buildpacks_scrape_error | Whether the last scrape of Buildpacks metrics from Cloud Foundry resulted in an error (`1` for error, `0` for success) | `environment`, `deployment` |
+| *metrics.namespace*_last_buildpacks_scrape_timestamp | Number of seconds since 1970 since last scrape of Buildpacks metrics from Cloud Foundry | `environment`, `deployment` |
+| *metrics.namespace*_last_buildpacks_scrape_duration_seconds | Duration of the last scrape of Buildpacks metrics from Cloud Foundry | `environment`, `deployment` |
 
 The exporter returns the following `Events` metrics:
 

--- a/cf_exporter.go
+++ b/cf_exporter.go
@@ -51,7 +51,7 @@ var (
 	).Envar("CF_EXPORTER_EVENTS_QUERY").Default("").String()
 
 	filterCollectors = kingpin.Flag(
-		"filter.collectors", "Comma separated collectors to filter (Applications,Events,IsolationSegments,Organizations,Routes,SecurityGroups,ServiceBindings,ServiceInstances,ServicePlans,Services,Spaces,Stacks). If not set, all collectors except Events is enabled ($CF_EXPORTER_FILTER_COLLECTORS)",
+		"filter.collectors", "Comma separated collectors to filter (Applications,Buildpacks,Events,IsolationSegments,Organizations,Routes,SecurityGroups,ServiceBindings,ServiceInstances,ServicePlans,Services,Spaces,Stacks). If not set, all collectors except Events is enabled ($CF_EXPORTER_FILTER_COLLECTORS)",
 	).Envar("CF_EXPORTER_FILTER_COLLECTORS").Default("").String()
 
 	metricsNamespace = kingpin.Flag(
@@ -164,6 +164,11 @@ func main() {
 	if collectorsFilter.Enabled(filters.ApplicationsCollector) {
 		applicationsCollector := collectors.NewApplicationsCollector(*metricsNamespace, *metricsEnvironment, *cfDeploymentName, cfClient)
 		prometheus.MustRegister(applicationsCollector)
+	}
+
+	if collectorsFilter.Enabled(filters.BuildpacksCollector) {
+		buildpacksCollector := collectors.NewBuildpacksCollector(*metricsNamespace, *metricsEnvironment, *cfDeploymentName, cfClient)
+		prometheus.MustRegister(buildpacksCollector)
 	}
 
 	if collectorsFilter.Enabled(filters.IsolationSegmentsCollector) {

--- a/collectors/buildpacks_collector.go
+++ b/collectors/buildpacks_collector.go
@@ -1,0 +1,158 @@
+package collectors
+
+import (
+	"time"
+
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+)
+
+type BuildpacksCollector struct {
+	namespace                                 string
+	environment                               string
+	deployment                                string
+	cfClient                                  *cfclient.Client
+	buildpackInfoMetric                       *prometheus.GaugeVec
+	buildpacksScrapesTotalMetric              prometheus.Counter
+	buildpacksScrapeErrorsTotalMetric         prometheus.Counter
+	lastBuildpacksScrapeErrorMetric           prometheus.Gauge
+	lastBuildpacksScrapeTimestampMetric       prometheus.Gauge
+	lastBuildpacksScrapeDurationSecondsMetric prometheus.Gauge
+}
+
+func NewBuildpacksCollector(
+	namespace string,
+	environment string,
+	deployment string,
+	cfClient *cfclient.Client,
+) *BuildpacksCollector {
+	buildpackInfoMetric := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   "buildpack",
+			Name:        "info",
+			Help:        "Labeled Cloud Foundry Buildpack information with a constant '1' value.",
+			ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+		},
+		[]string{"buildpack_id", "buildpack_name", "buildpack_stack", "buildpack_filename"},
+	)
+
+	buildpacksScrapesTotalMetric := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   "buildpacks_scrapes",
+			Name:        "total",
+			Help:        "Total number of scrapes for Cloud Foundry Buildpacks.",
+			ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+		},
+	)
+
+	buildpacksScrapeErrorsTotalMetric := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   "buildpacks_scrape_errors",
+			Name:        "total",
+			Help:        "Total number of scrape error of Cloud Foundry Buildpacks.",
+			ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+		},
+	)
+
+	lastBuildpacksScrapeErrorMetric := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   "",
+			Name:        "last_buildpacks_scrape_error",
+			Help:        "Whether the last scrape of Buildpacks metrics from Cloud Foundry resulted in an error (1 for error, 0 for success).",
+			ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+		},
+	)
+
+	lastBuildpacksScrapeTimestampMetric := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   "",
+			Name:        "last_buildpacks_scrape_timestamp",
+			Help:        "Number of seconds since 1970 since last scrape of Buildpacks metrics from Cloud Foundry.",
+			ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+		},
+	)
+
+	lastBuildpacksScrapeDurationSecondsMetric := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   "",
+			Name:        "last_buildpacks_scrape_duration_seconds",
+			Help:        "Duration of the last scrape of Buildpacks metrics from Cloud Foundry.",
+			ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+		},
+	)
+
+	return &BuildpacksCollector{
+		namespace:                                 namespace,
+		environment:                               environment,
+		deployment:                                deployment,
+		cfClient:                                  cfClient,
+		buildpackInfoMetric:                       buildpackInfoMetric,
+		buildpacksScrapesTotalMetric:              buildpacksScrapesTotalMetric,
+		buildpacksScrapeErrorsTotalMetric:         buildpacksScrapeErrorsTotalMetric,
+		lastBuildpacksScrapeErrorMetric:           lastBuildpacksScrapeErrorMetric,
+		lastBuildpacksScrapeTimestampMetric:       lastBuildpacksScrapeTimestampMetric,
+		lastBuildpacksScrapeDurationSecondsMetric: lastBuildpacksScrapeDurationSecondsMetric,
+	}
+}
+
+func (c BuildpacksCollector) Collect(ch chan<- prometheus.Metric) {
+	var begun = time.Now()
+
+	errorMetric := float64(0)
+	if err := c.reportBuildpacksMetrics(ch); err != nil {
+		errorMetric = float64(1)
+		c.buildpacksScrapeErrorsTotalMetric.Inc()
+	}
+	c.buildpacksScrapeErrorsTotalMetric.Collect(ch)
+
+	c.buildpacksScrapesTotalMetric.Inc()
+	c.buildpacksScrapesTotalMetric.Collect(ch)
+
+	c.lastBuildpacksScrapeErrorMetric.Set(errorMetric)
+	c.lastBuildpacksScrapeErrorMetric.Collect(ch)
+
+	c.lastBuildpacksScrapeTimestampMetric.Set(float64(time.Now().Unix()))
+	c.lastBuildpacksScrapeTimestampMetric.Collect(ch)
+
+	c.lastBuildpacksScrapeDurationSecondsMetric.Set(time.Since(begun).Seconds())
+	c.lastBuildpacksScrapeDurationSecondsMetric.Collect(ch)
+}
+
+func (c BuildpacksCollector) Describe(ch chan<- *prometheus.Desc) {
+	c.buildpackInfoMetric.Describe(ch)
+	c.buildpacksScrapesTotalMetric.Describe(ch)
+	c.buildpacksScrapeErrorsTotalMetric.Describe(ch)
+	c.lastBuildpacksScrapeErrorMetric.Describe(ch)
+	c.lastBuildpacksScrapeTimestampMetric.Describe(ch)
+	c.lastBuildpacksScrapeDurationSecondsMetric.Describe(ch)
+}
+
+func (c BuildpacksCollector) reportBuildpacksMetrics(ch chan<- prometheus.Metric) error {
+	c.buildpackInfoMetric.Reset()
+
+	buildpacks, err := c.cfClient.ListBuildpacks()
+	if err != nil {
+		log.Errorf("Error while listing buildpacks: %v", err)
+		return err
+	}
+
+	for _, buildpack := range buildpacks {
+		c.buildpackInfoMetric.WithLabelValues(
+			buildpack.Guid,
+			buildpack.Name,
+			buildpack.Stack,
+			buildpack.Filename,
+		).Set(float64(1))
+	}
+
+	c.buildpackInfoMetric.Collect(ch)
+
+	return nil
+}

--- a/collectors/buildpacks_collector_test.go
+++ b/collectors/buildpacks_collector_test.go
@@ -1,0 +1,276 @@
+package collectors_test
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+
+	. "github.com/bosh-prometheus/cf_exporter/collectors"
+	. "github.com/bosh-prometheus/cf_exporter/utils/test_matchers"
+)
+
+func init() {
+	log.Base().SetLevel("fatal")
+}
+
+var _ = Describe("BuildpacksCollectors", func() {
+	var (
+		err      error
+		server   *ghttp.Server
+		cfClient *cfclient.Client
+
+		buildpackInfoMetric                       *prometheus.GaugeVec
+		buildpacksScrapesTotalMetric              prometheus.Counter
+		buildpacksScrapeErrorsTotalMetric         prometheus.Counter
+		lastBuildpacksScrapeErrorMetric           prometheus.Gauge
+		lastBuildpacksScrapeTimestampMetric       prometheus.Gauge
+		lastBuildpacksScrapeDurationSecondsMetric prometheus.Gauge
+
+		namespace          = "test_namespace"
+		environment        = "test_environment"
+		deployment         = "test_deployment"
+		buildpackId1       = "fake_buildpack_id_1"
+		buildpackName1     = "fake_buildpack_name_1"
+		buildpackStack1    = "fake_buildpack_stack_1"
+		buildpackFilename1 = "fake_buildpack_filename_1"
+		buildpackId2       = "fake_buildpack_id_2"
+		buildpackName2     = "fake_buildpack_name_2"
+		buildpackStack2    = "fake_buildpack_stack_2"
+		buildpackFilename2 = "fake_buildpack_filename_2"
+
+		buildpacksCollector *BuildpacksCollector
+	)
+
+	BeforeEach(func() {
+		server = ghttp.NewServer()
+		server.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", "/v2/info"),
+				ghttp.RespondWith(http.StatusOK, "{}"),
+			),
+		)
+
+		cfClient, err = cfclient.NewClient(&cfclient.Config{
+			ApiAddress: server.URL(),
+			Token:      "fake-token",
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(server.ReceivedRequests())).To(Equal(1))
+
+		buildpackInfoMetric = prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Subsystem:   "buildpack",
+				Name:        "info",
+				Help:        "Labeled Cloud Foundry Buildpack information with a constant '1' value.",
+				ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+			},
+			[]string{"buildpack_id", "buildpack_name", "buildpack_stack", "buildpack_filename"},
+		)
+		buildpackInfoMetric.WithLabelValues(buildpackId1, buildpackName1, buildpackStack1, buildpackFilename1).Set(1)
+		buildpackInfoMetric.WithLabelValues(buildpackId2, buildpackName2, buildpackStack2, buildpackFilename2).Set(1)
+
+		buildpacksScrapesTotalMetric = prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace:   namespace,
+				Subsystem:   "buildpacks_scrapes",
+				Name:        "total",
+				Help:        "Total number of scrapes for Cloud Foundry Buildpacks.",
+				ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+			},
+		)
+		buildpacksScrapesTotalMetric.Inc()
+
+		buildpacksScrapeErrorsTotalMetric = prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace:   namespace,
+				Subsystem:   "buildpacks_scrape_errors",
+				Name:        "total",
+				Help:        "Total number of scrape error of Cloud Foundry Buildpacks.",
+				ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+			},
+		)
+
+		lastBuildpacksScrapeErrorMetric = prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Subsystem:   "",
+				Name:        "last_buildpacks_scrape_error",
+				Help:        "Whether the last scrape of Buildpacks metrics from Cloud Foundry resulted in an error (1 for error, 0 for success).",
+				ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+			},
+		)
+
+		lastBuildpacksScrapeTimestampMetric = prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Subsystem:   "",
+				Name:        "last_buildpacks_scrape_timestamp",
+				Help:        "Number of seconds since 1970 since last scrape of Buildpacks metrics from Cloud Foundry.",
+				ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+			},
+		)
+
+		lastBuildpacksScrapeDurationSecondsMetric = prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Subsystem:   "",
+				Name:        "last_buildpacks_scrape_duration_seconds",
+				Help:        "Duration of the last scrape of Buildpacks metrics from Cloud Foundry.",
+				ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+			},
+		)
+	})
+
+	JustBeforeEach(func() {
+		buildpacksCollector = NewBuildpacksCollector(namespace, environment, deployment, cfClient)
+	})
+
+	AfterEach(func() {
+		server.Close()
+	})
+
+	Describe("Describe", func() {
+		var (
+			descriptions chan *prometheus.Desc
+		)
+
+		BeforeEach(func() {
+			descriptions = make(chan *prometheus.Desc)
+		})
+
+		JustBeforeEach(func() {
+			go buildpacksCollector.Describe(descriptions)
+		})
+
+		It("returns a buildpack_info metric description", func() {
+			Eventually(descriptions).Should(Receive(Equal(buildpackInfoMetric.WithLabelValues(
+				buildpackId1,
+				buildpackName1,
+				buildpackStack1,
+				buildpackFilename1,
+			).Desc())))
+		})
+
+		It("returns a buildpacks_scrapes_total metric description", func() {
+			Eventually(descriptions).Should(Receive(Equal(buildpacksScrapesTotalMetric.Desc())))
+		})
+
+		It("returns a buildpacks_scrape_errors_total metric description", func() {
+			Eventually(descriptions).Should(Receive(Equal(buildpacksScrapeErrorsTotalMetric.Desc())))
+		})
+
+		It("returns a last_buildpacks_scrape_error metric description", func() {
+			Eventually(descriptions).Should(Receive(Equal(lastBuildpacksScrapeErrorMetric.Desc())))
+		})
+
+		It("returns a last_buildpacks_scrape_timestamp metric description", func() {
+			Eventually(descriptions).Should(Receive(Equal(lastBuildpacksScrapeTimestampMetric.Desc())))
+		})
+
+		It("returns a last_buildpacks_scrape_duration_seconds metric description", func() {
+			Eventually(descriptions).Should(Receive(Equal(lastBuildpacksScrapeDurationSecondsMetric.Desc())))
+		})
+	})
+
+	Describe("Collect", func() {
+		var (
+			statusCode         int
+			buildpacksResponse cfclient.BuildpackResponse
+			metrics            chan prometheus.Metric
+		)
+
+		BeforeEach(func() {
+			statusCode = http.StatusOK
+			buildpacksResponse = cfclient.BuildpackResponse{
+				Resources: []cfclient.BuildpackResource{
+					cfclient.BuildpackResource{
+						Meta: cfclient.Meta{
+							Guid: buildpackId1,
+						},
+						Entity: cfclient.Buildpack{
+							Name:     buildpackName1,
+							Filename: buildpackFilename1,
+							Stack:    buildpackStack1,
+						},
+					},
+					cfclient.BuildpackResource{
+						Meta: cfclient.Meta{
+							Guid: buildpackId2,
+						},
+						Entity: cfclient.Buildpack{
+							Name:     buildpackName2,
+							Filename: buildpackFilename2,
+							Stack:    buildpackStack2,
+						},
+					},
+				},
+			}
+			metrics = make(chan prometheus.Metric)
+		})
+
+		JustBeforeEach(func() {
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/v2/buildpacks"),
+					ghttp.RespondWithJSONEncodedPtr(&statusCode, &buildpacksResponse),
+				),
+			)
+
+			go buildpacksCollector.Collect(metrics)
+		})
+
+		It("returns a buildpack_info metric for buildpack 1", func() {
+			Eventually(metrics).Should(Receive(PrometheusMetric(buildpackInfoMetric.WithLabelValues(
+				buildpackId1,
+				buildpackName1,
+				buildpackStack1,
+				buildpackFilename1,
+			))))
+		})
+
+		It("returns a buildpack_info metric for buildpack 2", func() {
+			Eventually(metrics).Should(Receive(PrometheusMetric(buildpackInfoMetric.WithLabelValues(
+				buildpackId2,
+				buildpackName2,
+				buildpackStack2,
+				buildpackFilename2,
+			))))
+		})
+
+		It("returns a buildpacks_scrapes_total metric", func() {
+			Eventually(metrics).Should(Receive(PrometheusMetric(buildpacksScrapesTotalMetric)))
+		})
+
+		It("returns a buildpacks_scrape_errors_total metric", func() {
+			Eventually(metrics).Should(Receive(PrometheusMetric(buildpacksScrapeErrorsTotalMetric)))
+		})
+
+		It("returns a last_buildpacks_scrape_error metric", func() {
+			Eventually(metrics).Should(Receive(PrometheusMetric(lastBuildpacksScrapeErrorMetric)))
+		})
+
+		Context("when it fails to list the buildpacks", func() {
+			BeforeEach(func() {
+				statusCode = http.StatusInternalServerError
+
+				buildpacksScrapeErrorsTotalMetric.Inc()
+				lastBuildpacksScrapeErrorMetric.Set(1)
+			})
+
+			It("returns a buildpacks_scrape_errors_total metric", func() {
+				Eventually(metrics).Should(Receive(PrometheusMetric(buildpacksScrapeErrorsTotalMetric)))
+			})
+
+			It("returns a last_buildpacks_scrape_error metric", func() {
+				Eventually(metrics).Should(Receive(PrometheusMetric(lastBuildpacksScrapeErrorMetric)))
+			})
+		})
+	})
+})

--- a/filters/collectors_filter.go
+++ b/filters/collectors_filter.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	ApplicationsCollector      = "Applications"
+	BuildpacksCollector        = "Buildpacks"
 	EventsCollector            = "Events"
 	IsolationSegmentsCollector = "IsolationSegments"
 	OrganizationsCollector     = "Organizations"
@@ -33,6 +34,8 @@ func NewCollectorsFilter(filters []string, cfAPIv3Enabled bool) (*CollectorsFilt
 		switch strings.Trim(collectorName, " ") {
 		case ApplicationsCollector:
 			collectorsEnabled[ApplicationsCollector] = true
+		case BuildpacksCollector:
+			collectorsEnabled[BuildpacksCollector] = true
 		case EventsCollector:
 			collectorsEnabled[EventsCollector] = true
 		case IsolationSegmentsCollector:

--- a/filters/collectors_filter_test.go
+++ b/filters/collectors_filter_test.go
@@ -25,6 +25,7 @@ var _ = Describe("CollectorsFilter", func() {
 			BeforeEach(func() {
 				filters = []string{
 					ApplicationsCollector,
+					BuildpacksCollector,
 					OrganizationsCollector,
 					RoutesCollector,
 					SecurityGroupsCollector,
@@ -123,6 +124,10 @@ var _ = Describe("CollectorsFilter", func() {
 					Expect(collectorsFilter.Enabled(ApplicationsCollector)).To(BeTrue())
 				})
 
+				It("Buildpacks Collector should be enabled", func() {
+					Expect(collectorsFilter.Enabled(BuildpacksCollector)).To(BeTrue())
+				})
+
 				It("Isolation Segments Collector should be enabled", func() {
 					Expect(collectorsFilter.Enabled(IsolationSegmentsCollector)).To(BeTrue())
 				})
@@ -171,6 +176,10 @@ var _ = Describe("CollectorsFilter", func() {
 
 				It("Applications Collector should be enabled", func() {
 					Expect(collectorsFilter.Enabled(ApplicationsCollector)).To(BeTrue())
+				})
+
+				It("Buildpacks Collector should be enabled", func() {
+					Expect(collectorsFilter.Enabled(BuildpacksCollector)).To(BeTrue())
 				})
 
 				It("Isolation Segments Collector should be disabled", func() {


### PR DESCRIPTION
Collector will return information about installed buildpacks.

The following labels added to `buildpack_info_metric`:
- buildpack_id
- buildpack_name
- buildpack_stack
- buildpack_filename

Example metric:
```
cf_buildpack_info{buildpack_filename="java-buildpack-cflinuxfs3-v4.19.1.zip",buildpack_id="51a74f02-79d4-48ff-94bf-dfe76eb4e422",buildpack_name="java_buildpack",buildpack_stack="cflinuxfs3",deployment="cf",environment="bbl-3"} 1
```

Fixes #37 

/cc @frodenas 