### PR TITLE
[WIP] Add cache for expensive metrics

### DIFF
--- a/collectors/schedule.go
+++ b/collectors/schedule.go
@@ -1,0 +1,29 @@
+package collectors
+
+import (
+	"time"
+
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
+)
+
+func schedule(cfClient *cfclient.Client, x func(a *cfclient.Client), interval time.Duration) *time.Ticker {
+	x(cfClient)
+	ticker := time.NewTicker(interval)
+	go func() {
+		for range ticker.C {
+			x(cfClient)
+		}
+	}()
+	return ticker
+}
+
+func (c ApplicationsCollector) appSchedule(interval time.Duration) *time.Ticker {
+	appErrorCache = c.getApplicationMetrics()
+	ticker := time.NewTicker(interval)
+	go func() {
+		for range ticker.C {
+			appErrorCache = c.getApplicationMetrics()
+		}
+	}()
+	return ticker
+}


### PR DESCRIPTION
We have been having some issues with particularly expensive metrics being essentially impossible to query just-in-time. Not sure about your all's environments, but for us we were seeing scrape times of over a minute, enough to cause some issues with the prometheus lookback delta.

We also just didn't want to have a lot of concurrent scrapes on CF if, for example, someone holds down the F5 button, or if we just have a lot of prometheus instances scraping at once (the latter is more likely).

I've added a cache to a few collectors, which queries CF every 5 minutes. Just taking care of these three collectors reduced our scrape times to about 5s.

If you like this idea, I figured I could implement for the other collectors as well, and perhaps add a parameter that would allow users to select a refresh time (in seconds).

Would also appreciate any code review as this is my first time using go.