### PR TITLE
fix tests

### DIFF
--- a/fetcher/sessionext_test.go
+++ b/fetcher/sessionext_test.go
@@ -77,6 +77,13 @@ var _ = Describe("Extensions", func() {
 			),
 		)
 
+		server.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest("POST", "/oauth/token"),
+				ghttp.RespondWith(http.StatusOK, tokenResponse),
+			),
+		)
+
 		config = &CFConfig{
 			URL:          server.URL(),
 			ClientID:     "fake",


### PR DESCRIPTION
Somehow the GitHub tests were successful in the past, although there should have been the following errors:
```
Summarizing 6 Failures:

[Fail] Extensions fetching applications [It] no error occurs
/Users/robertgogolok/workspace/cf_exporter/vendor/github.com/onsi/gomega/ghttp/handlers.go:48

[Fail] Extensions fetching tasks [It] no error occurs
/Users/robertgogolok/workspace/cf_exporter/vendor/github.com/onsi/gomega/ghttp/handlers.go:48

[Fail] Extensions fetching org quotas [It] no error occurs
/Users/robertgogolok/workspace/cf_exporter/vendor/github.com/onsi/gomega/ghttp/handlers.go:48

[Fail] Extensions fetching space quotas [It] no error occurs
/Users/robertgogolok/workspace/cf_exporter/vendor/github.com/onsi/gomega/ghttp/handlers.go:48

[Fail] Extensions fetching space summary [It] no error occurs
/Users/robertgogolok/workspace/cf_exporter/vendor/github.com/onsi/gomega/ghttp/handlers.go:48

[Fail] Extensions fetching app events [It] no error occurs
/Users/robertgogolok/workspace/cf_exporter/vendor/github.com/onsi/gomega/ghttp/handlers.go:48
```

The /oauth/token endpoint is being hit 3 times in a row.