### PR TITLE
Fix golangci linter warning "parameter 'r' seems to be unused"

### DIFF
--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func main() {
 
 	handler := prometheusHandler()
 	http.Handle(*metricsPath, handler)
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		_, err := w.Write([]byte(`<html>
              <head><title>Cloud Foundry Exporter</title></head>
              <body>


### PR DESCRIPTION
Fix [golangci linter warning](https://github.com/bosh-prometheus/cf_exporter/actions/runs/7901207206/job/21564307594#step:4:25) : ` Warning: unused-parameter: parameter 'r' seems to be unused, consider removing or renaming it as _ (revive)`