### PR TITLE
Ensure buildpacks is not empty when trying to access it

### DIFF
--- a/collectors/applications.go
+++ b/collectors/applications.go
@@ -329,9 +329,9 @@ func (c ApplicationsCollector) collectAppBuildpacks(application models.Applicati
 				if len(detectedBuildpack) == 0 {
 					detectedBuildpack = buildpack
 				}
-			}
-			if len(buildpack) == 0 {
-				buildpack = detectedBuildpack
+				if len(buildpack) == 0 {
+					buildpack = detectedBuildpack
+				}
 			}
 			// 3.Use the droplet data for the buildpack metric
 			for _, bp := range droplet.Buildpacks {


### PR DESCRIPTION
Fixes #188 

The original idea was to use the lifecycle type, which should be the mid-term/ long-term solution on this topic but apparently that is not available (yet) in here: 

https://github.com/cloudfoundry/cli/blob/3a79eefed58aa116e59696d152196d5813794ea5/resources/droplet_resource.go#L12

Will create a PR to make it available in there so we can afterwards switch to use that instead of the length of the buildpack array. 