### PR TITLE
Introduce dedicated BBS scrape error; do not fail API scrape

### DIFF
--- a/collectors/bbs.go
+++ b/collectors/bbs.go
@@ -87,7 +87,7 @@ func NewBBSCollector(
 
 func (c BBSCollector) Collect(objs *models.CFObjects, ch chan<- prometheus.Metric) {
 	errorMetric := float64(0)
-	if objs.BBSActualLRPsError != nil {
+	if objs.Error != nil || objs.BBSActualLRPsError != nil {
 		errorMetric = float64(1)
 		c.bbsActualLRPsScrapeErrorsTotalMetric.Inc()
 	}

--- a/collectors/bbs.go
+++ b/collectors/bbs.go
@@ -1,0 +1,115 @@
+package collectors
+
+import (
+	"time"
+
+	"github.com/cloudfoundry/cf_exporter/v2/models"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type BBSCollector struct {
+	namespace                                    string
+	environment                                  string
+	deployment                                   string
+	bbsActualLRPsScrapesTotalMetric              prometheus.Counter
+	bbsActualLRPsScrapeErrorsTotalMetric         prometheus.Counter
+	lastBBSActualLRPsScrapeErrorMetric           prometheus.Gauge
+	lastBBSActualLRPsScrapeTimestampMetric       prometheus.Gauge
+	lastBBSActualLRPsScrapeDurationSecondsMetric prometheus.Gauge
+}
+
+func NewBBSCollector(
+	namespace string,
+	environment string,
+	deployment string,
+) *BBSCollector {
+	bbsActualLRPsScrapesTotalMetric := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   "bbs_actual_lrps_scrapes",
+			Name:        "total",
+			Help:        "Total number of BBS ActualLRPs scrapes.",
+			ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+		},
+	)
+
+	bbsActualLRPsScrapeErrorsTotalMetric := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   "bbs_actual_lrps_scrape_errors",
+			Name:        "total",
+			Help:        "Total number of BBS ActualLRPs scrape errors.",
+			ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+		},
+	)
+
+	lastBBSActualLRPsScrapeErrorMetric := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   "",
+			Name:        "last_bbs_actual_lrps_scrape_error",
+			Help:        "Whether the last BBS ActualLRPs scrape resulted in an error (1 for error, 0 for success).",
+			ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+		},
+	)
+
+	lastBBSActualLRPsScrapeTimestampMetric := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   "",
+			Name:        "last_bbs_actual_lrps_scrape_timestamp",
+			Help:        "Number of seconds since 1970 since last BBS ActualLRPs scrape attempt.",
+			ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+		},
+	)
+
+	lastBBSActualLRPsScrapeDurationSecondsMetric := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   "",
+			Name:        "last_bbs_actual_lrps_scrape_duration_seconds",
+			Help:        "Duration of the last BBS ActualLRPs scrape attempt.",
+			ConstLabels: prometheus.Labels{"environment": environment, "deployment": deployment},
+		},
+	)
+
+	return &BBSCollector{
+		namespace:                                    namespace,
+		environment:                                  environment,
+		deployment:                                   deployment,
+		bbsActualLRPsScrapesTotalMetric:              bbsActualLRPsScrapesTotalMetric,
+		bbsActualLRPsScrapeErrorsTotalMetric:         bbsActualLRPsScrapeErrorsTotalMetric,
+		lastBBSActualLRPsScrapeErrorMetric:           lastBBSActualLRPsScrapeErrorMetric,
+		lastBBSActualLRPsScrapeTimestampMetric:       lastBBSActualLRPsScrapeTimestampMetric,
+		lastBBSActualLRPsScrapeDurationSecondsMetric: lastBBSActualLRPsScrapeDurationSecondsMetric,
+	}
+}
+
+func (c BBSCollector) Collect(objs *models.CFObjects, ch chan<- prometheus.Metric) {
+	errorMetric := float64(0)
+	if objs.BBSActualLRPsError != nil {
+		errorMetric = float64(1)
+		c.bbsActualLRPsScrapeErrorsTotalMetric.Inc()
+	}
+
+	c.bbsActualLRPsScrapeErrorsTotalMetric.Collect(ch)
+	c.bbsActualLRPsScrapesTotalMetric.Inc()
+	c.bbsActualLRPsScrapesTotalMetric.Collect(ch)
+
+	c.lastBBSActualLRPsScrapeErrorMetric.Set(errorMetric)
+	c.lastBBSActualLRPsScrapeErrorMetric.Collect(ch)
+
+	c.lastBBSActualLRPsScrapeTimestampMetric.Set(float64(time.Now().Unix()))
+	c.lastBBSActualLRPsScrapeTimestampMetric.Collect(ch)
+
+	c.lastBBSActualLRPsScrapeDurationSecondsMetric.Set(objs.Took)
+	c.lastBBSActualLRPsScrapeDurationSecondsMetric.Collect(ch)
+}
+
+func (c BBSCollector) Describe(ch chan<- *prometheus.Desc) {
+	c.bbsActualLRPsScrapesTotalMetric.Describe(ch)
+	c.bbsActualLRPsScrapeErrorsTotalMetric.Describe(ch)
+	c.lastBBSActualLRPsScrapeErrorMetric.Describe(ch)
+	c.lastBBSActualLRPsScrapeTimestampMetric.Describe(ch)
+	c.lastBBSActualLRPsScrapeDurationSecondsMetric.Describe(ch)
+}

--- a/collectors/collectors.go
+++ b/collectors/collectors.go
@@ -117,6 +117,11 @@ func NewCollector(
 		res.collectors = append(res.collectors, collector)
 	}
 
+	if filter.Enabled(filters.ActualLRPs) {
+		collector := NewBBSCollector(namespace, environment, deployment)
+		res.collectors = append(res.collectors, collector)
+	}
+
 	return res, nil
 }
 

--- a/collectors/collectors.go
+++ b/collectors/collectors.go
@@ -1,6 +1,8 @@
 package collectors
 
 import (
+	"strings"
+
 	"github.com/cloudfoundry/cf_exporter/v2/fetcher"
 	"github.com/cloudfoundry/cf_exporter/v2/filters"
 	"github.com/cloudfoundry/cf_exporter/v2/models"
@@ -117,7 +119,7 @@ func NewCollector(
 		res.collectors = append(res.collectors, collector)
 	}
 
-	if filter.Enabled(filters.ActualLRPs) {
+	if filter.Enabled(filters.ActualLRPs) && bbsConfig != nil && strings.TrimSpace(bbsConfig.URL) != "" {
 		collector := NewBBSCollector(namespace, environment, deployment)
 		res.collectors = append(res.collectors, collector)
 	}

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -104,6 +104,7 @@ func (c *Fetcher) fetch() *models.CFObjects {
 		bbs, err = NewBBSClient(c.bbsConfig)
 		if err != nil {
 			log.WithError(err).Error("unable to initialize bbs client")
+			result.BBSActualLRPsError = err
 			c.filters.Disable([]string{filters.ActualLRPs})
 		}
 	}

--- a/fetcher/fetcher_handlers.go
+++ b/fetcher/fetcher_handlers.go
@@ -41,8 +41,10 @@ func (c *Fetcher) fetchActualLRPs(_ *SessionExt, bbs *BBSClient, entry *models.C
 		}
 	} else {
 		log.Errorf("could not fetch actual lrps: %s", err)
+		entry.BBSActualLRPsError = err
+		return nil
 	}
-	return err
+	return nil
 }
 
 func (c *Fetcher) fetchInfo(session *SessionExt, _ *BBSClient, entry *models.CFObjects) error {

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -345,6 +345,7 @@ var _ = ginkgo.Describe("Fetcher", func() {
 			objs := fetcher.GetObjects()
 
 			gomega.Ω(objs.Error).ShouldNot(gomega.HaveOccurred())
+			gomega.Ω(objs.BBSActualLRPsError).Should(gomega.HaveOccurred())
 			gomega.Ω(objs.Info.Name).Should(gomega.Equal("test-foundation"))
 			gomega.Ω(objs.ProcessActualLRPs).Should(gomega.BeEmpty())
 			gomega.Ω(fetcher.filters.Enabled(filters.ActualLRPs)).Should(gomega.BeFalse())

--- a/models/model.go
+++ b/models/model.go
@@ -39,6 +39,7 @@ type CFObjects struct {
 	Users                map[string]resources.User                     `json:"users"`
 	ServiceRouteBindings map[string]resources.RouteBinding             `json:"service_route_bindings"`
 	Took                 float64
+	BBSActualLRPsError   error
 	Error                error
 }
 
@@ -180,6 +181,7 @@ func NewCFObjects() *CFObjects {
 		Events:               map[string]Event{},
 		ServiceRouteBindings: map[string]resources.RouteBinding{},
 		Took:                 0,
+		BBSActualLRPsError:   nil,
 		Error:                nil,
 	}
 }


### PR DESCRIPTION
At the moment, if fetching infos from BBS API fails, all CF API metrics report a scrape error and the scrape run stops; As the BBS metrics use a different source this should not happen, therefore this PR aims to introduce a dedicated scrape error metric for BBS metrics, which does not cause the other CF API related metrics to report a scrape error nor does it cause the Exporter to stop its scrape run;